### PR TITLE
Wait for hardware when RESET command issued

### DIFF
--- a/mmeowlink/vendors/serial_rf_spy.py
+++ b/mmeowlink/vendors/serial_rf_spy.py
@@ -57,6 +57,8 @@ class SerialRfSpy:
 
   def do_command(self, command, param="", timeout=0):
     self.send_command(command, param, timeout=timeout)
+    if command == self.CMD_RESET:
+	time.sleep(1)
     return self.get_response(timeout=timeout)
 
   def send_command(self, command, param="", timeout=1):


### PR DESCRIPTION
Not 100% sure this is the right thing to do, but if the RESET command is issued to the hardware, it seems (from looking at a logic analyser) that there needs to be a pause before carrying on reading/writing.
