### PR TITLE
Don't reset device

### DIFF
--- a/mmeowlink/vendors/subg_rfspy_link.py
+++ b/mmeowlink/vendors/subg_rfspy_link.py
@@ -67,8 +67,8 @@ class SubgRfspyLink(SerialInterface):
 
   def check_setup(self):
     self.serial_rf_spy = SerialRfSpy(self.serial)
-    if self.device.find('spi') >= 0:
-        self.serial_rf_spy.do_command(SerialRfSpy.CMD_RESET, param="", timeout=1)
+#    if self.device.find('spi') >= 0:
+#        self.serial_rf_spy.do_command(SerialRfSpy.CMD_RESET, param="", timeout=1)
     self.serial_rf_spy.sync()
 
     # Check it's a SerialRfSpy device by retrieving the firmware version


### PR DESCRIPTION
Remove the reset call, as this seems to stop the pump responding properly. In conjunction with https://github.com/EnhancedRadioDevices/915MHzEdisonExplorer_SW/issues/2#issuecomment-247179237 this should allow reading the pump model, simply re-run mmtune then `openaps use pump model`
